### PR TITLE
Updating Netty version, splitting deps and adding native support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <netty.version>4.1.67.Final</netty.version>
+        <netty.version>4.1.76.Final</netty.version>
+        <netty.epoll.classifier>linux-x86_64</netty.epoll.classifier>
+        <netty.kqueue.classifier>osx-x86_64</netty.kqueue.classifier>
         <log4j.version>2.14.1</log4j.version>
         <kafka-clients.version>3.1.0</kafka-clients.version>
         <junit.version>5.8.1</junit.version>
@@ -78,14 +80,54 @@
     </dependencyManagement>
 
     <dependencies>
-
+        <!-- We depend on the specific Netty dependencies not netty-all to reduce the size of fatjars -->
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
+            <artifactId>netty-common</artifactId>
             <version>${netty.version}</version>
-            <scope>compile</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
+            <classifier>${netty.epoll.classifier}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-epoll</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <version>${netty.version}</version>
+            <classifier>${netty.kqueue.classifier}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-kqueue</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>


### PR DESCRIPTION
This would enable using the right native version, if present.
In the future, by adding the io_uring incubator, we can make use of it transparently